### PR TITLE
Correct the list of packages to install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ msvcbuild.bat static
 10.  Copy `projects\windows\vs2022\x86\Release\gmsv_turbostroi_win32.dll` to `GarrysModDS\garrysmod\lua\bin` (create `bin` folder if it doesn't exist) 
 
 # Manual for Linux GCC compile:
-1. Install `gcc-multilib`
+1. Install `gcc-multilib` and `g++-multilib`
 ```
-apt install gcc-multilib
+apt install gcc-multilib g++-multilib
 ```
 2. [Get](https://premake.github.io/download) `premake5` for Linux
 3. Place and run `premake5` in this folder:

--- a/README_ru.md
+++ b/README_ru.md
@@ -47,9 +47,9 @@ msvcbuild.bat static
 10. Скопируйте `projects\windows\vs2022\x86\Release\gmsv_turbostroi_win32.dll` в `GarrysModDS\garrysmod\lua\bin` (создайте папку `bin`, если её нет)
 
 # Компиляция под Linux GCC:
-1. Установите пакет `gcc-multilib`
+1. Установите пакет `gcc-multilib` и `g++-multilib`
 ```
-apt install gcc-multilib
+apt install gcc-multilib g++-multilib
 ```
 2. [Скачайте](https://premake.github.io/download) `premake5` для Linux
 3. Скопируйте и запустите `premake5` в папке с этим репозиторием:


### PR DESCRIPTION
Without g++-multilib you may get the error:
```
==== Building helpers (release_x86) ====
Creating x86/Release/intermediate/helpers
ModuleLoader.cpp
In file included from ../../../helpers/include/GarrysMod/ModuleLoader.hpp:3,
                 from ../../../helpers/source/ModuleLoader.cpp:1:
/usr/include/c++/12/string:38:10: fatal error: bits/c++config.h: Нет такого файла или каталога
   38 | #include <bits/c++config.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:178: x86/Release/intermediate/helpers/ModuleLoader.o] Ошибка 1
make: *** [Makefile:76: helpers] Ошибка 2
```